### PR TITLE
feat: balancing APIs load

### DIFF
--- a/utils/starkscan/retrieveTx.ts
+++ b/utils/starkscan/retrieveTx.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+import config from "../../config";
+import { execWithRateLimit } from "../execWithRateLimit";
+
+type RetrieveTxParameters = {
+  starknetNetwork: "mainnet" | "goerli";
+  txHash: string;
+};
+
+export const retrieveTx = async ({
+  starknetNetwork,
+  txHash,
+}: RetrieveTxParameters) => {
+  const network = starknetNetwork === "mainnet" ? "api" : "api-testnet";
+  const apiKey = config.STARKSCAN_API_KEY;
+  try {
+    const { data } = await execWithRateLimit(
+      async () =>
+        await axios.get(
+          `https://${network}.starkscan.co/api/v0/transaction/${txHash}`,
+          {
+            headers: {
+              "x-api-key": apiKey,
+            },
+          }
+        ),
+      "starkscan"
+    );
+    return data;
+  } catch (e) {
+    console.log(`[Starkscan] Error while fetching tx: ${e}`);
+    return null;
+  }
+};


### PR DESCRIPTION
When the starknet API is overloaded, we use the starkscan API. (Both are used to retrieve contract address from tx hash)