### PR TITLE
fix: refresh when connecting wallet

### DIFF
--- a/indexer/indexer.ts
+++ b/indexer/indexer.ts
@@ -63,7 +63,7 @@ const launchIndexer = async (
     url: networkUrl,
     token: AUTH_TOKEN,
     onReconnect,
-    timeout: 1000 * 60 * 5, // 5 minutes
+    timeout: 1000 * 60 * 30, // 30 minutes
   });
 
   // Starknet provider

--- a/pages/api/verify.ts
+++ b/pages/api/verify.ts
@@ -52,6 +52,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<Data>) => {
   }
   const discordConfigs = await DiscordServerConfigRepository.findBy({
     discordServerId: discordMember.discordServerId,
+    starknetNetwork: body.network,
   });
 
   const messageHexHash = typedData.getMessageHash(messageToSign, body.account);

--- a/utils/preLoadMemberAssets.ts
+++ b/utils/preLoadMemberAssets.ts
@@ -8,10 +8,10 @@ import { compareTwoHexStrings } from "./string";
 const loadAssets = async (
   walletAddress: string,
   networkName: NetworkName,
-  transferConfigs: DiscordServerConfig[],
+  assetConfigs: DiscordServerConfig[],
   contractFilter: (address: string) => boolean
 ) => {
-  const contractAddresses = transferConfigs
+  const contractAddresses = assetConfigs
     .map((config) => config.starkyModuleConfig.contractAddress)
     .filter(contractFilter)
     // Remove duplicates


### PR DESCRIPTION
We only want to refresh configs on the network used to connect the wallet. E.g. Starky shouldn't refresh mainnet configs for a user who connected his wallet on goerli