### PR TITLE
fix: specifying node url when calling contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react-dom": "18.2.0",
         "reflect-metadata": "^0.1.13",
         "sass": "^1.54.5",
-        "starknet": "^5.24.2",
+        "starknet": "^5.24.3",
         "ts-node": "^10.9.1",
         "ts-parse-database-url": "^1.0.3",
         "typeorm": "^0.3.17",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-dom": "18.2.0",
     "reflect-metadata": "^0.1.13",
     "sass": "^1.54.5",
-    "starknet": "^5.24.2",
+    "starknet": "^5.24.3",
     "ts-node": "^10.9.1",
     "ts-parse-database-url": "^1.0.3",
     "typeorm": "^0.3.17",

--- a/utils/starknet/call.ts
+++ b/utils/starknet/call.ts
@@ -24,6 +24,7 @@ export const callContract = async ({
 }: CallContractParameters) => {
   const provider = new RpcProvider({
     chainId: chainAliasByNetwork[starknetNetwork][1] as any,
+    nodeUrl: chainAliasByNetwork[starknetNetwork][0],
   });
   const rawCalldata: RawCalldata = [];
   calldata?.forEach((d) => rawCalldata.push(getRawCallData(d)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,7 +2971,7 @@ starknet@^3.12.3:
     ts-custom-error "^3.2.0"
     url-join "^4.0.1"
 
-starknet@^5.24.2:
+starknet@^5.24.3:
   version "5.24.3"
   resolved "https://registry.npmjs.org/starknet/-/starknet-5.24.3.tgz"
   integrity sha512-v0TuaNc9iNtHdbIRzX372jfQH1vgx2rwBHQDMqK4DqjJbwFEE5dog8Go6rGiZVW750NqRSWrZ7ahqyRNc3bscg==


### PR DESCRIPTION
This was an issue because the API seemed to always be called for testnet (even if it should have called mainnet).