### PR TITLE
Fix: Automatically trigger network switch in Argent Wallet if on wrong network

### DIFF
--- a/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
+++ b/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
@@ -221,17 +221,6 @@ const VerifyPage = ({
                     {switchError && "Network switch failed. Please try again."}
                     {showSuccess &&
                       "Network switched successfully! Connecting..."}
-                    {!switchError && !showSuccess && (
-                      <div>
-                        Required network: {starknetNetwork}
-                        <button
-                          onClick={connectToStarknet}
-                          style={{ marginLeft: "10px" }}
-                        >
-                          Retry
-                        </button>
-                      </div>
-                    )}
                   </>
                 )
               ) : (

--- a/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
+++ b/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
@@ -116,6 +116,7 @@ const VerifyPage = ({
           refreshedWallet.account?.provider.chainId ||
           refreshedWallet.provider?.chainId ||
           refreshedWallet.chainId;
+        setChainId(newChainId);
         const isValid = chainAliasByNetwork[starknetNetwork].some(
           (id) => id.toLowerCase() === newChainId?.toLowerCase()
         );

--- a/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
+++ b/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
@@ -98,13 +98,11 @@ const VerifyPage = ({
     const handleNetworkSwitch = async (wallet: any) => {
       setIsSwitching(true);
       try {
-        // Request network switch
         await wallet.request({
           type: "wallet_switchStarknetChain",
           params: { chainId: getTargetChainId() },
         });
 
-        // Wait for network update and reconnect
         await new Promise((resolve) => setTimeout(resolve, 1000));
         const { wallet: refreshedWallet } = await starknetConnect();
 
@@ -114,13 +112,10 @@ const VerifyPage = ({
           return;
         }
 
-        // Get updated chain ID
         const newChainId =
           refreshedWallet.account?.provider.chainId ||
           refreshedWallet.provider?.chainId ||
           refreshedWallet.chainId;
-
-        // Case-insensitive validation
         const isValid = chainAliasByNetwork[starknetNetwork].some(
           (id) => id.toLowerCase() === newChainId?.toLowerCase()
         );

--- a/styles/Verify.module.scss
+++ b/styles/Verify.module.scss
@@ -14,6 +14,7 @@
     background-color: transparent;    
     transition: background-color 0.3s ease;
     cursor: pointer;
+    margin-bottom: 1rem;
   
     &:hover {
       background-color: #fefee9;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -53,3 +53,7 @@ a {
 .danger {
   color: #c3453f;
 }
+
+.success {
+  color: #4a9d4a;
+}


### PR DESCRIPTION
Close: #116 

- [x] Detect when the user connects with the correct chain but the wrong network (currently the only chain we support is starknet, but stellar will come soon.
- [x] Check if the user is using Argent Wallet.
- [x] If the user is on Argent Wallet, trigger a popup to switch networks automatically.
- [x] If the user is on Braavos or another wallet that does not support this, display the existing message as a fallback.
- [x] Ensure smooth UI interaction without blocking other functionalities.