### PR TITLE
Fix signature error

### DIFF
--- a/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
+++ b/pages/verify/[discordServerId]/[discordMemberId]/[customLink].tsx
@@ -34,6 +34,15 @@ const getSignatureErrorMessage = (
         "your wallet is not yet initialized, please make a transaction (sending ETH to yourself works) to initialize it",
       advanced: error,
     };
+  
+  // Handle the specific undefined property error
+  if (error.includes("Cannot read properties of undefined") || error.includes("received empty result")) {
+    return {
+      short: "your wallet signature verification failed, please try again or try using a different wallet",
+      advanced: "The contract response was invalid. This may happen with some wallet implementations.",
+    };
+  }
+  
   return {
     short: "your signature could not be verified, please try again",
     advanced: error,
@@ -329,7 +338,7 @@ const VerifyPage = ({
             <span>
               Identity: <b>verified</b>
             </span>
-            <h1>YOU’RE ALL SET FREN</h1>
+            <h1>YOU'RE ALL SET FREN</h1>
             <span>you shall close this tab</span>
           </div>
         )}

--- a/utils/starknet/verifySignature.ts
+++ b/utils/starknet/verifySignature.ts
@@ -24,6 +24,13 @@ export const verifySignature = async (
       calldata: [hexHash, `${signature.length}`, ...signature],
     });
 
+    if (!result || result.length === 0) {
+      return {
+        signatureValid: false,
+        error: "Invalid signature: received empty result",
+      };
+    }
+
     const signatureValid = result[0] === "0x1";
 
     return {
@@ -39,6 +46,13 @@ export const verifySignature = async (
         entrypoint: "is_valid_signature",
         calldata: [hexHash, `${signature.length}`, ...signature],
       });
+
+      if (!result || result.length === 0) {
+        return {
+          signatureValid: false,
+          error: "Invalid signature: received empty result",
+        };
+      }
 
       const signatureValid =
         result[0] === "0x1" ||


### PR DESCRIPTION
This PR addresses the "your signature could not be verified, please try again advanced: Signature is invalid. Cannot read properties of undefined (reading '0')" error that occurs during the wallet signature verification process.


Changes implemented:
Added null/undefined checks in verifySignature.ts:
Implemented proper validation before accessing result[0] in both primary and fallback signature verification flows
Added explicit error handling with descriptive messages when encountering undefined or empty results

Enhanced error messaging for users:
Updated the getSignatureErrorMessage function to detect and handle this specific error case
Added a user-friendly error message recommending to "try again or try using a different wallet"
Included a technical explanation in the advanced section that clarifies the issue for developers


Technical details:
The error was occurring when the contract call returned undefined results but the code attempted to access index 0 of the result array. The fix now properly validates the response before attempting to access array elements, preventing the JavaScript runtime error and providing meaningful feedback.


Testing:
Verified that the application now gracefully handles undefined results during signature verification without crashing, and presents users with actionable error messages.

Issue
Close #133