### PR TITLE
Add starky-dashboard command

### DIFF
--- a/db/data-source.ts
+++ b/db/data-source.ts
@@ -5,6 +5,7 @@ import "reflect-metadata";
 import config from "../config";
 
 import { DiscordAnalyticsToken } from "./entity/DiscordAnalyticsToken";
+import { DiscordDashboardToken } from "./entity/DiscordDashboardToken";
 import { DiscordServer } from "./entity/DiscordServer";
 import { DiscordServerConfig } from "./entity/DiscordServerConfig";
 import { DiscordMember } from "./entity/DiscordMember";
@@ -25,6 +26,7 @@ export const AppDataSource = new DataSource({
     DiscordMember,
     NetworkStatus,
     DiscordAnalyticsToken,
+    DiscordDashboardToken,
   ],
   migrations: [__dirname + "/migration/**/*.{js,ts}"],
   migrationsTableName: "migrations",

--- a/db/entity/DiscordDashboardToken.ts
+++ b/db/entity/DiscordDashboardToken.ts
@@ -1,0 +1,32 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+  } from "typeorm";
+  
+  @Entity({ name: "discord_dashboard_token" })
+  export class DiscordDashboardToken {
+    @PrimaryGeneratedColumn()
+    id: number;
+  
+    @Column()
+    guildId: string;
+  
+    @Column()
+    userId: string;
+  
+    @Column({ unique: true })
+    token: string;
+  
+    @CreateDateColumn()
+    createdAt: Date;
+  
+    @Column({ type: "timestamptz" }) // Use UTC timestamps
+    expiresAt: Date;
+  
+    @ManyToOne("discord_server", "discord_dashboard_token")
+    discordServer: any;
+  }
+  

--- a/db/index.ts
+++ b/db/index.ts
@@ -5,6 +5,7 @@ import { DiscordServerConfig } from "./entity/DiscordServerConfig";
 import { NetworkStatus } from "./entity/NetworkStatus";
 import { AppDataSource } from "./data-source";
 import { setupMigrations } from "./setup-migrations";
+import { DiscordDashboardToken } from "./entity/DiscordDashboardToken";
 
 export const setupDb = async () => {
   if (!AppDataSource.isInitialized) {
@@ -28,4 +29,7 @@ export const NetworkStatusRepository =
 
 export const DiscordAnalyticsTokenRepository = AppDataSource.getRepository(
   DiscordAnalyticsToken
+);
+export const DiscordDashboardTokenRepository = AppDataSource.getRepository(
+  DiscordDashboardToken
 );

--- a/db/migration/1743266004193-CreateDiscordDashboardTokenTable.ts
+++ b/db/migration/1743266004193-CreateDiscordDashboardTokenTable.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateDiscordDashboardTokenTable1743266004193 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "discord_dashboard_token" (
+              "id" SERIAL PRIMARY KEY,
+              "guildId" VARCHAR NOT NULL,
+              "userId" VARCHAR NOT NULL,
+              "token" VARCHAR UNIQUE NOT NULL,
+              "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+              "expiresAt" TIMESTAMP NOT NULL,
+              "discordServerId" VARCHAR REFERENCES "discord_server"("id")
+            );
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "discord_dashboard_token"`);
+    }
+
+}

--- a/discord/commands/index.ts
+++ b/discord/commands/index.ts
@@ -289,4 +289,8 @@ export const slashCommandsArray: SlashCommandData[] = [
     name: "starky-analytics",
     description: "View analytics for this server",
   },
+  {
+    name: "starky-dashboard",
+    description: "View the Starky dashboard for this server",
+  },
 ];

--- a/discord/commands/index.ts
+++ b/discord/commands/index.ts
@@ -23,6 +23,7 @@ import {
   handleDisconnectConfirmCommand,
 } from "../interactions/disconnectCommand";
 import { handleAnalyticsCommand } from "../interactions/handleAnalyticsCommand";
+import { handleDashboardCommand } from "../interactions/handleDashboardCommand";
 import { handleHelpCommand } from "../interactions/helpCommand";
 import { handleListConfigsCommand } from "../interactions/listConfigs";
 import { handleRefreshCommand } from "../interactions/refreshCommand";
@@ -145,6 +146,11 @@ export const interactionHandlers: HandlerConfig[] = [
     type: "chatInput",
     identifier: "starky-analytics",
     handler: handleAnalyticsCommand,
+  },
+  {
+    type: "chatInput",
+    identifier: "starky-dashboard",
+    handler: handleDashboardCommand,
   },
   {
     type: "selectMenu",

--- a/discord/interactions/handleAnalyticsCommand.ts
+++ b/discord/interactions/handleAnalyticsCommand.ts
@@ -24,7 +24,7 @@ export const handleAnalyticsCommand = async (
     {
       // TODO * await saveTokenToDatabase(guildId, userId, token); */
     }
-    await saveTokenToDatabase(guildId, userId, token);
+    await saveTokenToDatabase(guildId, userId, token, "analytics");
 
     // Construct the analytics URL with the token
     const analyticsUrl = `${process.env.BASE_URL}/analytics/${guildId}/${token}`;

--- a/discord/interactions/handleAnalyticsCommand.ts
+++ b/discord/interactions/handleAnalyticsCommand.ts
@@ -21,9 +21,6 @@ export const handleAnalyticsCommand = async (
     const token = uuidv4();
 
     // Store the token in the database with guildId and userId
-    {
-      // TODO * await saveTokenToDatabase(guildId, userId, token); */
-    }
     await saveAnalyticsTokenToDatabase(guildId, userId, token);
 
     // Construct the analytics URL with the token

--- a/discord/interactions/handleAnalyticsCommand.ts
+++ b/discord/interactions/handleAnalyticsCommand.ts
@@ -2,7 +2,7 @@ import { REST } from "@discordjs/rest";
 import { ChatInputCommandInteraction, Client } from "discord.js";
 import { v4 as uuidv4 } from "uuid"; // For token generation
 
-import { saveTokenToDatabase } from "../../utils/database"; // Assume DB handling function
+import { saveAnalyticsTokenToDatabase } from "../../utils/database"; // Assume DB handling function
 
 export const handleAnalyticsCommand = async (
   interaction: ChatInputCommandInteraction,
@@ -24,7 +24,7 @@ export const handleAnalyticsCommand = async (
     {
       // TODO * await saveTokenToDatabase(guildId, userId, token); */
     }
-    await saveTokenToDatabase(guildId, userId, token, "analytics");
+    await saveAnalyticsTokenToDatabase(guildId, userId, token);
 
     // Construct the analytics URL with the token
     const analyticsUrl = `${process.env.BASE_URL}/analytics/${guildId}/${token}`;

--- a/discord/interactions/handleDashboardCommand.ts
+++ b/discord/interactions/handleDashboardCommand.ts
@@ -1,0 +1,38 @@
+import { REST } from "@discordjs/rest";
+import { ChatInputCommandInteraction, Client } from "discord.js";
+import { v4 as uuidv4 } from "uuid"; // For token generation
+
+import { saveTokenToDatabase } from "../../utils/database"; // Assume DB handling function
+
+
+export const handleDashboardCommand = async (
+    interaction: ChatInputCommandInteraction,
+    client: Client,
+    restClient: REST
+) => {
+    try{
+        // Extract guildId and userId from the interaction
+        const userId = interaction.member?.user?.id;
+        const guildId = interaction.guildId;
+
+        // Ensure both userId and guildId are present
+        if (!userId || !guildId) return;
+
+        // Generate a unique token (UUID or crypto-based)
+        const token = uuidv4();
+
+        // Store the token in the database with guildId and userId
+        await saveTokenToDatabase(guildId, userId, token);
+
+        // Construct the dashboard URL with the token
+        const dashboardUrl = `${process.env.BASE_URL}/dashboard/${guildId}/${token}`;
+        // Send the URL to the user in an ephemeral message
+        await interaction.reply({
+            content: `View Dashboard here: [Click Here](${dashboardUrl})`,
+            ephemeral: true,
+        });
+    } catch (error) {
+        // Handle errors gracefully
+        console.error("Error handling /analytics command:", error);
+    }
+}

--- a/discord/interactions/handleDashboardCommand.ts
+++ b/discord/interactions/handleDashboardCommand.ts
@@ -2,7 +2,7 @@ import { REST } from "@discordjs/rest";
 import { ChatInputCommandInteraction, Client } from "discord.js";
 import { v4 as uuidv4 } from "uuid"; // For token generation
 
-import { saveTokenToDatabase } from "../../utils/database"; // Assume DB handling function
+import { saveDashboardTokenToDatabase } from "../../utils/database"; // Assume DB handling function
 
 
 export const handleDashboardCommand = async (
@@ -22,7 +22,7 @@ export const handleDashboardCommand = async (
         const token = uuidv4();
 
         // Store the token in the database with guildId and userId
-        await saveTokenToDatabase(guildId, userId, token, "dashboard");
+        await saveDashboardTokenToDatabase(guildId, userId, token);
 
         // Construct the dashboard URL with the token
         const dashboardUrl = `${process.env.BASE_URL}/dashboard/${guildId}/${token}`;

--- a/discord/interactions/handleDashboardCommand.ts
+++ b/discord/interactions/handleDashboardCommand.ts
@@ -22,7 +22,7 @@ export const handleDashboardCommand = async (
         const token = uuidv4();
 
         // Store the token in the database with guildId and userId
-        await saveTokenToDatabase(guildId, userId, token);
+        await saveTokenToDatabase(guildId, userId, token, "dashboard");
 
         // Construct the dashboard URL with the token
         const dashboardUrl = `${process.env.BASE_URL}/dashboard/${guildId}/${token}`;
@@ -33,6 +33,6 @@ export const handleDashboardCommand = async (
         });
     } catch (error) {
         // Handle errors gracefully
-        console.error("Error handling /analytics command:", error);
+        console.error("Error handling /dashboard command:", error);
     }
 }

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -1,25 +1,12 @@
 import { DiscordAnalyticsTokenRepository, DiscordDashboardTokenRepository } from "../db";
 
-type AccessType = "analytics" | "dashboard";
 
-export const saveTokenToDatabase = async (
+export const saveAnalyticsTokenToDatabase = async (
   guildId: string,
   userId: string,
-  token: string,
-  accessType: AccessType,
+  token: string
 ) => {
   try {
-    if (accessType == "dashboard"){
-      const dashbaordToken = DiscordDashboardTokenRepository.create({
-        token,
-        guildId,
-        userId,
-        createdAt: new Date(),
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // Expires in 7 days - 1 week
-      });
-      await DiscordAnalyticsTokenRepository.save(dashbaordToken);
-    }
-    else{
       const analyticsToken = DiscordAnalyticsTokenRepository.create({
         token,
         guildId,
@@ -28,7 +15,24 @@ export const saveTokenToDatabase = async (
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // Expires in 7 days - 1 week
       });
       await DiscordAnalyticsTokenRepository.save(analyticsToken);
-    }
+  } catch (error) {
+    console.error("Error saving token:", error);
+  }
+};
+export const saveDashboardTokenToDatabase = async (
+  guildId: string,
+  userId: string,
+  token: string,
+) => {
+  try {
+      const dashbaordToken = DiscordDashboardTokenRepository.create({
+        token,
+        guildId,
+        userId,
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // Expires in 7 days - 1 week
+      });
+      await DiscordAnalyticsTokenRepository.save(dashbaordToken);
   } catch (error) {
     console.error("Error saving token:", error);
   }

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -1,20 +1,34 @@
-import { DiscordAnalyticsTokenRepository } from "../db";
+import { DiscordAnalyticsTokenRepository, DiscordDashboardTokenRepository } from "../db";
+
+type AccessType = "analytics" | "dashboard";
 
 export const saveTokenToDatabase = async (
   guildId: string,
   userId: string,
-  token: string
+  token: string,
+  accessType: AccessType,
 ) => {
   try {
-    const analyticsToken = DiscordAnalyticsTokenRepository.create({
-      token,
-      guildId,
-      userId,
-      createdAt: new Date(),
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // Expires in 7 days - 1 week
-    });
-
-    await DiscordAnalyticsTokenRepository.save(analyticsToken);
+    if (accessType == "dashboard"){
+      const dashbaordToken = DiscordDashboardTokenRepository.create({
+        token,
+        guildId,
+        userId,
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // Expires in 7 days - 1 week
+      });
+      await DiscordAnalyticsTokenRepository.save(dashbaordToken);
+    }
+    else{
+      const analyticsToken = DiscordAnalyticsTokenRepository.create({
+        token,
+        guildId,
+        userId,
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // Expires in 7 days - 1 week
+      });
+      await DiscordAnalyticsTokenRepository.save(analyticsToken);
+    }
   } catch (error) {
     console.error("Error saving token:", error);
   }


### PR DESCRIPTION
## Overview
This PR implements a new `/starky-dashboard` slash command for Discord that provides authenticated access to a guild's dashboard. The implementation reuses the authentication mechanism from the existing `/starky-analytics` command.

## Changes
- Added new `/starky-dashboard` slash command
- Implemented `handleDashboardCommand` handler function
- Reused auth system to generate and verify secure tokens
- Set up URL construction for the dashboard path
- Created TypeORM table for Discord Dashboard Token
- Generated migration file for Discord Dashboard Token
- Updated datasource to include Dashboard Token entity
- Modified `db/index` to include DiscordDashboardTokenRepository
- Updated `saveTokenToDatabase` function to accommodate saving dashboard token

## Implementation Details
- The command generates a unique token (UUID) for authentication
- Stores token in database along with guild and user IDs
- Constructs a URL in the format `/dashboard/<guild-id>/<token>`
- Responds with an ephemeral message containing the dashboard link
- Added necessary error handling

## Notes
- The actual dashboard page will be developed in a separate issue
- Environment variable `BASE_URL` is required for proper URL construction

## Related Issue
Close #158 