### PR TITLE
Fix: display Discord server name & icon on dashboard page (#184)

### DIFF
--- a/components/guild/Guild.tsx
+++ b/components/guild/Guild.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+import styles from "../../styles/Verify.module.scss";
+
+type GuildProps = {
+  discordServerName: string;
+  discordServerIcon?: string | null;
+};
+
+const Guild = ({ discordServerName, discordServerIcon }: GuildProps) => {
+  return (
+    <div className={styles.serverInfo}>
+      Discord server:
+      <span className={styles.serverDisplay}>
+        {discordServerIcon ? (
+          <Image
+            src={discordServerIcon}
+            alt="Discord Server Icon"
+            className={styles.discordIcon}
+            width={24}
+            height={24}
+          />
+        ) : (
+          <div className={styles.iconPlaceholder}>
+            {discordServerName?.[0]?.toUpperCase()}
+          </div>
+        )}
+        <b>{discordServerName}</b>
+      </span>
+    </div>
+  );
+};
+
+export default Guild;

--- a/components/verification/DiscordServerInfo.tsx
+++ b/components/verification/DiscordServerInfo.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import styles from "../../styles/Verify.module.scss";
+import Guild from "../guild/Guild";
 
 type DiscordServerInfoProps = {
   discordServerName: string;
@@ -26,25 +27,10 @@ const DiscordServerInfo = ({
 
   return (
     <div>
-      <div className={styles.serverInfo}>
-        Discord server:
-        <span className={styles.serverDisplay}>
-          {discordServerIcon ? (
-            <Image
-              src={discordServerIcon}
-              alt="Discord Server Icon"
-              className={styles.discordIcon}
-              width={24}
-              height={24}
-            />
-          ) : (
-            <div className={styles.iconPlaceholder}>
-              {discordServerName?.[0]?.toUpperCase()}
-            </div>
-          )}
-          <b>{discordServerName}</b>
-        </span>
-      </div>
+      <Guild
+        discordServerName={discordServerName}
+        discordServerIcon={discordServerIcon}
+      />
       <br />
       <span className={styles.networkDisplay}>
         {networkLabels[networkType]}

--- a/pages/dashboard/[guildId]/[tokenId].tsx
+++ b/pages/dashboard/[guildId]/[tokenId].tsx
@@ -1,7 +1,6 @@
 import { NextPage, GetServerSideProps } from "next";
 import Logo from "../../../components/Logo";
 import SocialLinks from "../../../components/SocialLinks";
-import DiscordServerInfo from "../../../components/verification/DiscordServerInfo";
 import styles from "../../../styles/Dashboard.module.scss";
 
 import {
@@ -11,6 +10,7 @@ import {
 } from "../../../db";
 import { StarkyModuleConfig } from "../../../types/starkyModules";
 import { getDiscordServerInfo } from "../../../discord/utils";
+import Guild from "../../../components/guild/Guild";
 
 interface Config {
   id: string;
@@ -50,11 +50,9 @@ const DashboardPage: NextPage<DashboardPageProps> = ({
     <div className={styles.container}>
       <Logo />
       <h1>Dashboard</h1>
-      <DiscordServerInfo
+      <Guild
         discordServerName={discordServerName!}
         discordServerIcon={discordServerIcon}
-        network={""}
-        networkType="starknet"
       />{" "}
       <section className={styles.configSection}>
         <h3>Configurations</h3>


### PR DESCRIPTION
# PR: Fix display of Discord server name & icon on dashboard page (Closes #184)

## Description
This PR updates the dashboard page to show the actual Discord server name and server icon instead of displaying the raw guild ID. It leverages the `<DiscordServerInfo />` component and fetches guild information server-side.

Closes #184.

## What Changed
- Updated `pages/dashboard/[guildId]/[tokenId].tsx`:
  - Imported and used `getDiscordServerInfo`.
  - Extended `getServerSideProps` to fetch `discordServerName` and `discordServerIcon`.
  - Modified the dashboard layout to display server info using `<DiscordServerInfo />` instead of a raw ID.

## Screenshots

<details>
<summary>Before</summary>

![Screenshot From 2025-04-26 08-24-47](https://github.com/user-attachments/assets/24f6aef8-e9aa-47cd-b291-d9919c2acaae)

*Displayed only Guild ID (raw number).*  

</details>

<details>
<summary>After</summary>

![Screenshot From 2025-04-26 08-29-53](https://github.com/user-attachments/assets/5eaf2371-6dd4-4193-8b06-5dad40463b0a)

*Displays server icon + server name properly.*  

</details>

## Checklist
- [x] I followed the project coding style.
- [x] No type errors (`tsc --noEmit` passes).
- [x] Manually tested on `http://localhost:8080/dashboard/:guildId/:tokenId`.
- [x] PR closes #184.

## How to Test
1. Start the dev server:
   ```bash
   yarn dev
   ```
2. Use `/dashboard` command in Discord to get the link.
3. Open the dashboard link.
4. Confirm that the server icon and server name appear correctly.
